### PR TITLE
Fix db export

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,9 +1,9 @@
 import 'dotenv/config';
-import { pgTable, serial, text, varchar } from 'drizzle-orm/pg-core';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL!,
 });
-const db = drizzle({ client: pool });
+export const db = drizzle({ client: pool });
+


### PR DESCRIPTION
## Summary
- export `db` from the database entrypoint
- remove unused imports in `src/db/index.ts`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685215be198c832dbfd5b53aa1bf7dc9